### PR TITLE
update to match new default_parts hash

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ Refinery::I18n.frontend_locales.each do |lang|
     menu_match: "^#{url}(\/|\/.+?|)$"
   ) do |page|
     Refinery::Pages.default_parts.each_with_index do |part, index|
-      page.parts.build title: part, body: nil, position: index
+      page.parts.build title: part[:title], slug: part[:slug], body: nil, position: index
     end
   end if defined?(Refinery::Page)
 end


### PR DESCRIPTION
fixes page part creation from seeds.rb. Matches now new page part convention: {title: '', slug: ''}
